### PR TITLE
update achavi links to https://overpass-api.de/achavi/

### DIFF
--- a/scripts/rss.php
+++ b/scripts/rss.php
@@ -36,7 +36,7 @@ while( $row = $res->fetch_assoc() ) {
     $date = strtotime($row['change_time']);
     $date_str = date(DATE_RSS, $date);
     print "\t\t<pubDate>$date_str</pubDate>\n";
-    $desc = "User <a href=\"http://openstreetmap.org/user/".rawurlencode($row['user_name'])."\">".htmlspecialchars($row['user_name'])."</a> has uploaded <a href=\"http://openstreetmap.org/browse/changeset/${row['changeset_id']}\">a changeset</a> in your watched area using ".htmlspecialchars($row['created_by']).", titled \"".htmlspecialchars($row['comment'])."\". <a href=\"$frontend_url?changeset=${row['changeset_id']}&show=1\">Show it on WhoDidIt</a> or <a href=\"http://nrenner.github.io/achavi/?changeset=${row['changeset_id']}\">in Achavi</a>.";
+    $desc = "User <a href=\"http://openstreetmap.org/user/".rawurlencode($row['user_name'])."\">".htmlspecialchars($row['user_name'])."</a> has uploaded <a href=\"http://openstreetmap.org/browse/changeset/${row['changeset_id']}\">a changeset</a> in your watched area using ".htmlspecialchars($row['created_by']).", titled \"".htmlspecialchars($row['comment'])."\". <a href=\"$frontend_url?changeset=${row['changeset_id']}&show=1\">Show it on WhoDidIt</a> or <a href=\"https://overpass-api.de/achavi/?changeset=${row['changeset_id']}\">in Achavi</a>.";
     $desc .= '<br><br>Statistics:<ul>';
     $desc .= '<li>Nodes: '.$row['nodes_created'].' created, '.$row['nodes_modified'].' modified, '.$row['nodes_deleted'].' deleted</li>';
     $desc .= '<li>Ways: '.$row['ways_created'].' created, '.$row['ways_modified'].' modified, '.$row['ways_deleted'].' deleted</li>';

--- a/www/whodidit.js
+++ b/www/whodidit.js
@@ -117,7 +117,7 @@ function init() {
                     var date_str = months[ch['change_time'].substr(5,2)-1] + ' ' + ch['change_time'].substr(8,2);
                     html += '<span style="color: '+color+';">' + date_str + '</span>';
                     html += ': <a href="http://openstreetmap.org/browse/changeset/' + ch['changeset_id'] + '" target="_blank">changeset</a>';
-					html += ' <a href="http://nrenner.github.io/achavi/?changeset=' + ch['changeset_id'] + '" title="Show in Achavi" target="_blank">[A]</a>';
+                    html += ' <a href="https://overpass-api.de/achavi/?changeset=' + ch['changeset_id'] + '" title="Show in Achavi" target="_blank">[A]</a>';
                     html += ' <a href="#" title="Filter by this changeset" onclick="setChangeset(' + ch['changeset_id'] + '); return false;" class="filter">[F]</a>';
                     html += ' by user <a href="http://openstreetmap.org/user/' + encodeURI(ch['user_name']) + '" target="_blank">' + htmlEscape(ch['user_name']) + '</a>';
                     html += ' <a href="#" title="Filter by this user" onclick="setUser(\'' + htmlEscape(ch['user_name']) + '\'); return false;" class="filter">[F]</a>';


### PR DESCRIPTION
The achavi attic version is now deployed on overpass-api.de as the main instance. The instance on nrenner.github.io will still be available and is intended as development/test stage. Also added https support.

Not tested!
